### PR TITLE
fix: remove `iv` reference from `encryptionInformation.method`

### DIFF
--- a/schema/tdf/manifest-json.md
+++ b/schema/tdf/manifest-json.md
@@ -55,13 +55,12 @@ Contains information describing the method of encryption. As well as information
 |`policy`|String|The policy object which has been JSON stringified, then base64 encoded. The policy object is described in its own section: [Policy Object](PolicyObject.md)|
 
 ## encryptionInformation.method
-An object which describes the information required to actually decrypt the payload once the key is retrieved. Includes the algorithm, and iv at a minimum.
+An object which describes the information required to actually decrypt the payload once the key is retrieved. Includes the algorithm and isStreamable.
 
 ```javascript
 "method": {
   "algorithm": "AES-256-GCM",
-  "isStreamable": true,
-  "iv": "D6s7cSgFXzhVkran"
+  "isStreamable": true
 }
 ```
 
@@ -69,7 +68,6 @@ An object which describes the information required to actually decrypt the paylo
 |---|---|---|
 |`algorithm`|String|The algorithm used for encryption. Currently the two available options are `aes-256-gcm`.|
 |`isStreamable`|Boolean|`isStreamable` designates whether or not a TDF payload is streamable. If it's streamable, the payload is broken into chunks, and individual hashes are generated per chunk to establish integrity of the individual chunks.|
-|`iv`|String|The initialization vector for the encrypted payload.|
 
 ## encryptionInformation.integrityInformation
 An object which allows an application to validate the integrity of the payload, or a chunk of a payload should it be a streamable TDF.


### PR DESCRIPTION
### Proposed Changes

This change would update the spec and remove `IV` from `EncryptionInformation.Method` as it seems unnecessary as it seems standard to prepend the `IV` to the cipher text. Also the current `IV` usage wouldn't work unless you reuse the `IV` for each chunk which we don't want to promote as it is bad practice.  

This would be a `PATCH` as clients are already not using the `IV` in `EncryptionInformation.Method`. 

Corresponding issue #22 

### Checklist

- [x] A clear description of the change has been included in this PR.
- [x] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](../CONTRIBUTING.md#version-changes) has been included in this PR.
- [ ] All schema validation tests have been updated appropriately and are passing.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: This PR should be made in branches prefixed with `draft-<change>`
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A link to a reference implementation (PR or set of PRs) of the change has been included in this PR.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A writeup has been included discussing the motivation and impact of this change.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: The minimum wait time has elapsed.
- [ ] DRAFT MERGE ONLY: Draft Semver has been updated in the VERSION file (optional)
- [ ] DRAFT MERGE ONLY: Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](../CONTRIBUTING.md#version-changes).
- [ ] This change otherwise adheres to the project [Contribution Guidelines](../CONTRIBUTING.md).
