### PR TITLE
fix: github pull request template links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ### Checklist
 
 - [ ] A clear description of the change has been included in this PR.
-- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](CONTRIBUTING.md#version-changes) has been included in this PR.
+- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes) has been included in this PR.
 - [ ] All schema validation tests have been updated appropriately and are passing.
 - [ ] MAJOR/MINOR VERSION CHANGES ONLY: This PR should be made in branches prefixed with `draft-<change>`
 - [ ] MAJOR/MINOR VERSION CHANGES ONLY: A link to a reference implementation (PR or set of PRs) of the change has been included in this PR.
@@ -13,5 +13,5 @@
 - [ ] MAJOR/MINOR VERSION CHANGES ONLY: The minimum wait time has elapsed.
 - [ ] DRAFT MERGE ONLY: Draft Semver has been updated in the VERSION file (optional)
 - [ ] DRAFT MERGE ONLY: Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
-- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](CONTRIBUTING.md#version-changes).
-- [ ] This change otherwise adheres to the project [Contribution Guidelines](CONTRIBUTING.md).
+- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes).
+- [ ] This change otherwise adheres to the project [Contribution Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ### Checklist
 
 - [ ] A clear description of the change has been included in this PR.
-- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](../CONTRIBUTING.md#version-changes) has been included in this PR.
+- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](CONTRIBUTING.md#version-changes) has been included in this PR.
 - [ ] All schema validation tests have been updated appropriately and are passing.
 - [ ] MAJOR/MINOR VERSION CHANGES ONLY: This PR should be made in branches prefixed with `draft-<change>`
 - [ ] MAJOR/MINOR VERSION CHANGES ONLY: A link to a reference implementation (PR or set of PRs) of the change has been included in this PR.
@@ -13,5 +13,5 @@
 - [ ] MAJOR/MINOR VERSION CHANGES ONLY: The minimum wait time has elapsed.
 - [ ] DRAFT MERGE ONLY: Draft Semver has been updated in the VERSION file (optional)
 - [ ] DRAFT MERGE ONLY: Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
-- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](../CONTRIBUTING.md#version-changes).
-- [ ] This change otherwise adheres to the project [Contribution Guidelines](../CONTRIBUTING.md).
+- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](CONTRIBUTING.md#version-changes).
+- [ ] This change otherwise adheres to the project [Contribution Guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
### Proposed Changes

This change isn't a spec change and tries to fix the links in the github issue/pr template. Currently they seem to 404 so I am adding the absolute link to the CONTRIBUTING.md file. 


### Checklist

- [x] A clear description of the change has been included in this PR.
- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](../CONTRIBUTING.md#version-changes) has been included in this PR.
- [ ] All schema validation tests have been updated appropriately and are passing.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: This PR should be made in branches prefixed with `draft-<change>`
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A link to a reference implementation (PR or set of PRs) of the change has been included in this PR.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A writeup has been included discussing the motivation and impact of this change.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: The minimum wait time has elapsed.
- [ ] DRAFT MERGE ONLY: Draft Semver has been updated in the VERSION file (optional)
- [ ] DRAFT MERGE ONLY: Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](../CONTRIBUTING.md#version-changes).
- [ ] This change otherwise adheres to the project [Contribution Guidelines](../CONTRIBUTING.md).
