### PR TITLE
fix: change phrasing of mimetype default

### DIFF
--- a/schema/tdf/Manifest.md
+++ b/schema/tdf/Manifest.md
@@ -35,7 +35,7 @@ The payload contains metadata required to access the TDF's payload, including _h
 |`url`|String|A url pointing to the location of the payload. For example, `0.payload`, as a file local to the TDF.|Yes|
 |`protocol`|String|Designates which protocol was used during encryption. Currently, only `zip` and `zipstream` are supported and are specified at time of encryption depending on the use of non-streaming vs. streaming encryption.|Yes|
 |`isEncrypted`|Boolean|Designates whether or not the payload is encrypted. This set by default to `true` for the time being and is intended for later expansion.|Yes|
-|`mimeType`|String|Specifies the type of file that is encrypted. Default is `application/octet-stream`. |No|
+|`mimeType`|String|Specifies the type of file that is encrypted. If no `mimeType` is provided then `application/octet-stream` should be assumed. |No|
 |`tdf_spec_version`|String|Semver version number of the TDF spec.|No|
 
 ## encryptionInformation


### PR DESCRIPTION
### Proposed Changes

* adjust the phrasing of the mimetype default, it is not required so using "default" could be confusing

### Checklist

- [ ] A clear description of the change has been included in this PR.
- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes) has been included in this PR.
- [ ] All schema validation tests have been updated appropriately and are passing.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: This PR should be made in branches prefixed with `draft-<change>`
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A link to a reference implementation (PR or set of PRs) of the change has been included in this PR.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A writeup has been included discussing the motivation and impact of this change.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: The minimum wait time has elapsed.
- [ ] DRAFT MERGE ONLY: Draft Semver has been updated in the VERSION file (optional)
- [ ] DRAFT MERGE ONLY: Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes).
- [ ] This change otherwise adheres to the project [Contribution Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md).
