### PR TITLE
chore: fix broken links to XML spec and nanotdf spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the official specification for OpenTDF, including the d
 
 [Client SDKs and server-side services](https://github.com/opentdf/platform) can be built upon this OpenTDF specification, ensuring standards-based security and enabling seamless interaction between different systems and organizations in a federated environment.
 
-OpenTDF derives its modern JSON-encoded format from the original [TDF XML Specification](https://www.dni.gov/index.php/who-we-are/organizations/ic-cio/ic-cio-related-menus/ic-cio-related-links/ic-technical-specifications/trusted-data-format). For details on interoperability with legacy TDF XML formats, please [contact us](mailto:support@opentdf.io).
+OpenTDF derives its modern JSON-encoded format from the original [TDF XML Specification](https://www.dni.gov/index.php/who-we-are/organizations/ic-cio/ic-technical-specifications/trusted-data-format-base). For details on interoperability with legacy TDF XML formats, please [contact us](mailto:support@opentdf.io).
 
 **Versioning:** This specification adheres to the [Semantic Versioning 2.0.0](https://semver.org/) standard.
 
@@ -113,7 +113,7 @@ It achieves minimal size by using a highly optimized binary structure and relyin
 
 While OpenTDF offers flexibility and rich metadata, NanoTDF prioritizes size efficiency for specific use cases. 
 
-**➡️ For details, please refer to the [NanoTDF Specification](../schema/nanotdf/README.md).** 
+**➡️ For details, please refer to the [NanoTDF Specification](../main/schema/nanotdf/README.md).** 
 
 ## Reference Implementation & SDKs
 


### PR DESCRIPTION
fix broken links
* DNI.org link to XML spec
* link to nanotdf spec

### Proposed Changes

*

### Checklist

- [ ] A clear description of the change has been included in this PR.
- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes) has been included in this PR.
- [ ] All schema validation tests have been updated appropriately and are passing.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: This PR should be made in branches prefixed with `draft-<change>`
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A link to a reference implementation (PR or set of PRs) of the change has been included in this PR.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A writeup has been included discussing the motivation and impact of this change.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: The minimum wait time has elapsed.
- [ ] DRAFT MERGE ONLY: Draft Semver has been updated in the VERSION file (optional)
- [ ] DRAFT MERGE ONLY: Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes).
- [ ] This change otherwise adheres to the project [Contribution Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md).
