### PR TITLE
doc: adds max manifest consideration to manifest documentation

### DIFF
--- a/schema/OpenTDF/manifest.md
+++ b/schema/OpenTDF/manifest.md
@@ -17,7 +17,7 @@ The manifest object contains the following top-level properties:
 
 ### Manifest Size Considerations
 
-The number of entries in the `integrityInformation.segments` array directly determines the manifest size. As segment count increases, manifest size grows proportionally. For example, a 1 TB TDF file with 1 MB segments will result in approximately one million segment entries in the manifest, which can make the manifest extremely large. To manage manifest size, you can either increase the segment size to reduce the number of segments, or adjust the maximum allowed manifest size in your implementation or SDK configuration.
+For larger payloads, the number of entries in the `integrityInformation.segments` array directly determines the manifest size. As segment count increases, the `integrityInformation` length grows proportionally. With the default settings, a 1 TB TDF file with 1 MB segments will result in approximately one million segment entries in the manifest. Some SDKs impose maximum length limits on the manifest. To avoid problems with very large payloads, either configure your client to allow larger manifest sizes or to encrypt with larger segment lengths.
 
 ## Full Manifest Example
 

--- a/schema/OpenTDF/manifest.md
+++ b/schema/OpenTDF/manifest.md
@@ -15,6 +15,10 @@ The manifest object contains the following top-level properties:
 | `encryptionInformation` | Object | Contains details about encryption, key access, integrity, and policy. See [Encryption Information Object](./encryption_information.md). | Yes       |
 | `assertions`            | Array  | Optional array of verifiable statements about the TDF or payload. See [Assertions Array](./assertion.md).      | No        |
 
+### Manifest Size Considerations
+
+The number of entries in the `integrityInformation.segments` array directly determines the manifest size. As segment count increases, manifest size grows proportionally. For example, a 1 TB TDF file with 1 MB segments will result in approximately one million segment entries in the manifest, which can make the manifest extremely large. To manage manifest size, you can either increase the segment size to reduce the number of segments, or adjust the maximum allowed manifest size in your implementation or SDK configuration.
+
 ## Full Manifest Example
 
 This example illustrates a complete `manifest.json` structure. Links point to detailed descriptions of each major section.


### PR DESCRIPTION
### Proposed Changes

* document max manifest size for large TDFs

### Checklist

- [ ] A clear description of the change has been included in this PR.
- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes) has been included in this PR.
- [ ] All schema validation tests have been updated appropriately and are passing.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: This PR should be made in branches prefixed with `draft-<change>`
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A link to a reference implementation (PR or set of PRs) of the change has been included in this PR.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A writeup has been included discussing the motivation and impact of this change.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: The minimum wait time has elapsed.
- [ ] DRAFT MERGE ONLY: Draft Semver has been updated in the VERSION file (optional)
- [ ] DRAFT MERGE ONLY: Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes).
- [ ] This change otherwise adheres to the project [Contribution Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md).
