### PR TITLE
fix: clarify method and signature field descriptions

### DIFF
--- a/schema/OpenTDF/assertion_binding.md
+++ b/schema/OpenTDF/assertion_binding.md
@@ -7,7 +7,7 @@ The `binding` object, nested within an [Assertion Object](./assertion.md), conta
 ```json
 "binding": {
   "method": "jws",
-  "signature": "eyJhbGciOiJSUzI1NiJ9..." // Base64URL encoded JWS string
+  "signature": "eyJhbGciOiJSUzI1NiJ9..." // JWS string
 }
 ```
 
@@ -15,5 +15,5 @@ The `binding` object, nested within an [Assertion Object](./assertion.md), conta
 
 | Parameter | Type   | Description                                                                                                                                                                                                                 | Required? |
 | --------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| method    | String | The cryptographic method used for the signature. jws (JSON Web Signature) is commonly used, implying standard JWS processing rules apply.                                                                                   | Yes       |
-| signature | String | The Base64URL encoded signature value (e.g., a JWS Compact Serialization string). The signature calculation MUST include the assertion content and sufficient TDF context (like policy or key info hash) to prevent replay. | Yes       |
+| method    | String | Binding format. This version defines only `"jws"` (JSON Web Signature, compact serialization).                                                                                   | Yes       |
+| signature | String | JWS compact serialization string binding the assertion to the `scope` target (`tdo` or `payload`), providing integrity and replay protection. | Yes       |

--- a/schema/OpenTDF/assertion_binding.md
+++ b/schema/OpenTDF/assertion_binding.md
@@ -15,5 +15,5 @@ The `binding` object, nested within an [Assertion Object](./assertion.md), conta
 
 | Parameter | Type   | Description                                                                                                                                                                                                                 | Required? |
 | --------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| method    | String | Binding format. This version defines only `"jws"` (JWS Compact Serialization string format defined by the JWS (RFC 7515) specification).                                                                                   | Yes       |
+| method    | String | Cryptographic binding format. The only supported value is `"jws"` (JSON Web Signature using JWS Compact Serialization as per RFC 7515).                                                                                   | Yes       |
 | signature | String | JWS compact serialization string binding the assertion to the `scope` target (`tdo` or `payload`), providing integrity and replay protection. | Yes       |

--- a/schema/OpenTDF/assertion_binding.md
+++ b/schema/OpenTDF/assertion_binding.md
@@ -15,5 +15,5 @@ The `binding` object, nested within an [Assertion Object](./assertion.md), conta
 
 | Parameter | Type   | Description                                                                                                                                                                                                                 | Required? |
 | --------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| method    | String | Binding format. This version defines only `"jws"` (JSON Web Signature, compact serialization).                                                                                   | Yes       |
+| method    | String | Binding format. This version defines only `"jws"` (JWS Compact Serialization string format defined by the JWS (RFC 7515) specification).                                                                                   | Yes       |
 | signature | String | JWS compact serialization string binding the assertion to the `scope` target (`tdo` or `payload`), providing integrity and replay protection. | Yes       |


### PR DESCRIPTION
Updated the description of 'method' and 'signature' fields to clarify their usage and format.

### Proposed Changes

*

### Checklist

- [ ] A clear description of the change has been included in this PR.
- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes) has been included in this PR.
- [ ] All schema validation tests have been updated appropriately and are passing.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: This PR should be made in branches prefixed with `draft-<change>`
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A link to a reference implementation (PR or set of PRs) of the change has been included in this PR.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A writeup has been included discussing the motivation and impact of this change.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: The minimum wait time has elapsed.
- [ ] DRAFT MERGE ONLY: Draft Semver has been updated in the VERSION file (optional)
- [ ] DRAFT MERGE ONLY: Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes).
- [ ] This change otherwise adheres to the project [Contribution Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md).
