### PR TITLE
Update assertion_statement.md

### DIFF
--- a/schema/OpenTDF/assertion_statement.md
+++ b/schema/OpenTDF/assertion_statement.md
@@ -6,14 +6,32 @@ The `statement` object, nested within an [Assertion Object](./assertion.md), con
 
 ```json
 "statement": {
-  "schema": "urn:nato:stanag:4774:confidentialitymetadatalabel:1:0",
+  "schema": "urn:com.exmaple:tdf ../../ExampleSchema/CDSM-TDF/CDSM-TDF",
   "format": "json-structured",
   "value": {
-      "Xmlns": "urn:nato:stanag:4774:confidentialitymetadatalabel:1:0",
-      "CreationTime": "2015-08-29T16:15:00Z",
-      "ConfidentialityInformation": { /* ... specific assertion info ... */ }
+        "CreationTime": "2019-01-17T09:15:00Z",
+    	  "cdsm:CdsManifestAssertion": {
+      	"cdsm:Originator": "Oracle",
+      	"cdsm:Product": "Java JDK 21 Linux",
+      	"cdsm:PayloadVersion": "21.0.1",
+      	"cdsm:CPE": "cpe:/a:oracle:java_jdk_linux",
+      	"cdsm:Arch": "64-bit",
+      	"cdsm:VirusScanList": {
+        	"cdsm:VirusScan": {
+          "cdsm:ScanVendor": "AV-Example-Vendor",
+          "cdsm:ScanVersion": "VSE8.88",
+          "cdsm:SignatureDate": "2019-01-17T09:00:00Z",
+          "cdsm:ScanResult": "clean"
+        }
+      },
+      "cdsm:VendorChecksum": {
+        "cdsm:MD5": "eddcdd2f6f14cdb37ff4a10763c61898",
+        "cdsm:SHA256": "844fc3d6679cec3da7cf8ca5bb831e0f1770192ffff7a9549dec4e0f41b9d77b"
+      }
+    }
   }
 }
+
 ```
 
 ## Fields


### PR DESCRIPTION
added an alternative example using CDSM assertion example highlighting a result of an AV scan.

### Proposed Changes

*Current example assertion causes confusion since it is also a classification label. And gets conflated with a access policy
This is a cosmetic change that substitutes a notional assertion that roughly follows the structure used by a CDSM-TDF assertion indicating the file was scanned by an AV

### Checklist

- [ ] A clear description of the change has been included in this PR.
- [ ] A clear description of whether this change is a _Major_, _Minor_, _Patch_ or _cosmetic_ change as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes) has been included in this PR.
- [ ] All schema validation tests have been updated appropriately and are passing.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: This PR should be made in branches prefixed with `draft-<change>`
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A link to a reference implementation (PR or set of PRs) of the change has been included in this PR.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: A writeup has been included discussing the motivation and impact of this change.
- [ ] MAJOR/MINOR VERSION CHANGES ONLY: The minimum wait time has elapsed.
- [ ] DRAFT MERGE ONLY: Draft Semver has been updated in the VERSION file (optional)
- [ ] DRAFT MERGE ONLY: Tagged this branch with new semver version and an annotation describing the change (ex: `git tag -s 4.1.0 -m "Spec version 4.1.0 - did a thing"`)
- [ ] DRAFT MERGE ONLY: Version numbers have been updated as per the [Versioning Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md#version-changes).
- [ ] This change otherwise adheres to the project [Contribution Guidelines](https://github.com/opentdf/spec/blob/main/CONTRIBUTING.md).
